### PR TITLE
feat: Phase 9 — 멀티테넌트 보안 강화 + 파이프라인 UX + E2E + YouTube 업로드

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This project follows a Council-based development process.
 
 ## Current Status
 
-**Phase 8-3 완료 + P7-3 UV Workspace Migration 완료**
+**Phase 9 완료 (2026-03-16)**
 
 | Phase | 설명 | 상태 |
 |-------|------|------|
@@ -35,6 +35,10 @@ This project follows a Council-based development process.
 | Phase 6 | Web Dashboard (Frontend) | 완료 |
 | Phase 8-3 | LLM 비용/사용량 추적 | 완료 |
 | Phase 7-3 | UV Workspace Migration (3-Package Split) | 완료 |
+| Phase 9-1 | 멀티테넌트 보안 강화 (워크스페이스 격리) | 완료 |
+| Phase 9-2 | 파이프라인 UX (취소/SSE/비용 표시) | 완료 |
+| Phase 9-3 | E2E 안정성 (Playwright + Arq 재시도 + Retry API) | 완료 |
+| Phase 9-4 | YouTube 업로드 강화 (DB 토큰 + 업로드 재시도) | 완료 |
 
 ## Tech Stack
 

--- a/packages/agents/yaa_agents/publisher/youtube_api.py
+++ b/packages/agents/yaa_agents/publisher/youtube_api.py
@@ -6,9 +6,11 @@ google-api-python-client는 optional dependency이므로, 미설치 시 명확�
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import stat
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -69,6 +71,7 @@ class YouTubeUploader:
     """YouTube Data API v3를 통한 영상 업로드 클라이언트.
 
     OAuth2 인증 흐름을 사용하며, 대용량 영상은 청크 업로드를 지원합니다.
+    DB 토큰이 제공되면 파일 기반 토큰보다 우선합니다.
     """
 
     def __init__(
@@ -77,6 +80,8 @@ class YouTubeUploader:
         client_secret: str,
         token_path: str = _TOKEN_FILE,
         chunk_size_mb: int = _DEFAULT_CHUNK_SIZE_MB,
+        token_json: str | None = None,
+        on_token_refresh: Callable[[str], None] | None = None,
     ) -> None:
         if not client_id:
             raise ValueError("client_id는 필수입니다")
@@ -87,6 +92,8 @@ class YouTubeUploader:
         self._client_secret = client_secret
         self._token_path = Path(token_path)
         self._chunk_size = chunk_size_mb * _BYTES_PER_MB
+        self._token_json = token_json
+        self._on_token_refresh = on_token_refresh
 
     async def upload(self, request: PublishRequest) -> PublishResult:
         """영상을 YouTube에 업로드합니다.
@@ -117,7 +124,7 @@ class YouTubeUploader:
                 media_body=media,
             )
 
-            response = self._execute_upload(insert_request)
+            response = await self._execute_upload_with_retry(insert_request)
             video_id = response.get("id", "")
 
             logger.info("영상 업로드 완료: video_id=%s", video_id)
@@ -194,8 +201,34 @@ class YouTubeUploader:
         )
 
     def _get_credentials(self) -> Any:
-        """OAuth2 자격증명을 가져옵니다 (토큰 파일 기반)."""
+        """OAuth2 자격증명을 가져옵니다.
+
+        DB 토큰(token_json)이 제공되면 파일 기반 토큰보다 우선합니다.
+        """
         _require_google_api()
+
+        # DB 토큰 우선
+        if self._token_json:
+            import json as _json
+
+            try:
+                token_data = _json.loads(self._token_json)
+                credentials = Credentials.from_authorized_user_info(
+                    token_data, _YOUTUBE_UPLOAD_SCOPE
+                )
+                if credentials and credentials.valid:
+                    return credentials
+
+                if credentials and credentials.expired and credentials.refresh_token:
+                    from google.auth.transport.requests import Request
+
+                    credentials.refresh(Request())
+                    refreshed_json = credentials.to_json()
+                    if self._on_token_refresh:
+                        self._on_token_refresh(refreshed_json)
+                    return credentials
+            except Exception as error:
+                logger.warning("DB 토큰 갱신 실패, 파일 토큰 시도: %s", error)
 
         if self._token_path.exists():
             credentials = Credentials.from_authorized_user_file(
@@ -302,6 +335,30 @@ class YouTubeUploader:
                 progress = int(status.progress() * 100)
                 logger.info("업로드 진행률: %d%%", progress)
         return response
+
+    async def _execute_upload_with_retry(
+        self, insert_request: Any, max_retries: int = 3
+    ) -> dict[str, Any]:
+        """재시도 로직이 포함된 업로드 실행.
+
+        QuotaExceededError, AuthenticationError는 즉시 실패.
+        그 외 일시적 에러는 지수 백오프로 재시도합니다.
+        """
+        for attempt in range(max_retries):
+            try:
+                return self._execute_upload(insert_request)
+            except (QuotaExceededError, AuthenticationError):
+                raise
+            except Exception as exc:
+                if attempt == max_retries - 1:
+                    raise
+                wait = 2 ** attempt  # 1s, 2s, 4s
+                logger.warning(
+                    "업로드 재시도 %d/%d (대기 %ds): %s", attempt + 1, max_retries, wait, exc
+                )
+                await asyncio.sleep(wait)
+        # unreachable
+        raise RuntimeError("업로드 재시도 루프에서 비정상 탈출")
 
     def _handle_upload_error(self, error: Exception) -> PublishResult:
         """업로드 에러를 처리하고 실패 결과를 반환합니다."""

--- a/packages/agents/yaa_agents/publisher/youtube_api.py
+++ b/packages/agents/yaa_agents/publisher/youtube_api.py
@@ -352,7 +352,7 @@ class YouTubeUploader:
             except Exception as exc:
                 if attempt == max_retries - 1:
                     raise
-                wait = 2 ** attempt  # 1s, 2s, 4s
+                wait = 2 ** attempt  # 1s, 2s (3rd attempt raises immediately)
                 logger.warning(
                     "업로드 재시도 %d/%d (대기 %ds): %s", attempt + 1, max_retries, wait, exc
                 )

--- a/packages/api/alembic/versions/e5f6a7b8c9d0_add_oauth_tokens_table.py
+++ b/packages/api/alembic/versions/e5f6a7b8c9d0_add_oauth_tokens_table.py
@@ -1,0 +1,42 @@
+"""Add oauth_tokens table for YouTube token persistence
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-03-16 00:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5f6a7b8c9d0'
+down_revision: str | Sequence[str] | None = 'd4e5f6a7b8c9'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'oauth_tokens',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column(
+            'workspace_id',
+            sa.String(36),
+            sa.ForeignKey('workspaces.id', ondelete='CASCADE'),
+            nullable=False,
+            index=True,
+            unique=True,
+        ),
+        sa.Column('provider', sa.String(20), nullable=False, server_default='youtube'),
+        sa.Column('token_json', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('oauth_tokens')

--- a/packages/api/tests/test_auth_isolation.py
+++ b/packages/api/tests/test_auth_isolation.py
@@ -1,0 +1,223 @@
+"""멀티테넌트 보안 격리 테스트 (Phase 9-1)."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from yaa_app.api.auth import hash_api_key
+from yaa_app.api.main import create_app
+from yaa_core.database.engine import get_db_session, init_db, set_session_factory
+from yaa_core.database.models import ApiKeyModel, PipelineRunModel, UsageEventModel, WorkspaceModel
+from yaa_core.database.repositories import ApiKeyRepository
+from yaa_core.shared.config import ChannelRegistry
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture()
+def _channels_dir(tmp_path: Path) -> Path:
+    channels = tmp_path / "channels"
+    channels.mkdir()
+    template = channels / "_template"
+    template.mkdir()
+    (template / "config.yaml").write_text(
+        "channel:\n  name: template\n  category: general\n  language: ko\n",
+        encoding="utf-8",
+    )
+    ch = channels / "test-channel"
+    ch.mkdir()
+    (ch / "config.yaml").write_text(
+        "channel:\n  name: 테스트\n  category: pets\n  language: ko\n",
+        encoding="utf-8",
+    )
+    return channels
+
+
+@pytest.fixture()
+def _registry(_channels_dir: Path) -> ChannelRegistry:
+    return ChannelRegistry(channels_dir=_channels_dir)
+
+
+@pytest.fixture()
+async def _db_session_factory():
+    factory = await init_db(TEST_DB_URL)
+    yield factory
+    await factory.kw["bind"].dispose()
+    set_session_factory(None)
+
+
+@pytest.fixture()
+def client_factory(_registry: ChannelRegistry, _db_session_factory):
+    """API 키 헤더를 지원하는 TestClient 팩토리를 반환합니다."""
+    from yaa_app.api.dependencies import get_channel_registry, get_settings
+    from yaa_core.shared.config import AppSettings
+
+    app = create_app()
+
+    test_settings = AppSettings(
+        disable_auth=False,
+        database_url=TEST_DB_URL,
+        channels_dir=str(_registry.channels_dir),
+        api_key_header="X-API-Key",
+    )
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_channel_registry] = lambda: _registry
+
+    async def _override_db_session():
+        async with _db_session_factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    app.dependency_overrides[get_db_session] = _override_db_session
+
+    return app, _db_session_factory
+
+
+async def _create_workspace_with_key(session_factory, name: str) -> tuple[str, str, str]:
+    """워크스페이스와 API 키를 생성하고 (workspace_id, plaintext_key, key_id)를 반환합니다."""
+    workspace_id = str(uuid.uuid4())
+    key_id = str(uuid.uuid4())
+    plaintext_key = f"yaa_test_{name}_{uuid.uuid4().hex[:8]}"
+    key_hash = hash_api_key(plaintext_key)
+
+    async with session_factory() as session:
+        ws = WorkspaceModel(
+            id=workspace_id,
+            name=f"Workspace {name}",
+            owner_id=str(uuid.uuid4()),
+        )
+        session.add(ws)
+
+        api_key = ApiKeyModel(
+            id=key_id,
+            key_hash=key_hash,
+            name=f"Key {name}",
+            scopes_json='["read","write","admin"]',
+            workspace_id=workspace_id,
+        )
+        session.add(api_key)
+        await session.commit()
+
+    return workspace_id, plaintext_key, key_id
+
+
+async def _create_run(session_factory, workspace_id: str) -> str:
+    """파이프라인 실행 레코드를 생성하고 run_id를 반환합니다."""
+    run_id = str(uuid.uuid4())
+    async with session_factory() as session:
+        run = PipelineRunModel(
+            id=run_id,
+            channel_id="test-channel",
+            topic="테스트 주제",
+            workspace_id=workspace_id,
+            status="completed",
+        )
+        session.add(run)
+        await session.commit()
+    return run_id
+
+
+async def _create_usage_event(session_factory, run_id: str) -> str:
+    """사용량 이벤트를 생성하고 event_id를 반환합니다."""
+    event_id = str(uuid.uuid4())
+    async with session_factory() as session:
+        event = UsageEventModel(
+            id=event_id,
+            run_id=run_id,
+            agent="script_writer",
+            provider="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_tokens=100,
+            completion_tokens=200,
+            total_tokens=300,
+            cost_usd=0.005,
+        )
+        session.add(event)
+        await session.commit()
+    return event_id
+
+
+class TestStatusEndpointIsolation:
+    """GET /status/{run_id} 워크스페이스 격리 테스트."""
+
+    async def test_워크스페이스A_토큰으로_B의_run_조회시_404(self, client_factory, _db_session_factory):
+        app, session_factory = client_factory
+
+        ws_a_id, key_a, _ = await _create_workspace_with_key(session_factory, "A")
+        ws_b_id, _, _ = await _create_workspace_with_key(session_factory, "B")
+        run_b_id = await _create_run(session_factory, ws_b_id)
+
+        with TestClient(app) as c:
+            resp = c.get(f"/api/v1/status/{run_b_id}", headers={"X-API-Key": key_a})
+
+        assert resp.status_code == 404
+
+    async def test_워크스페이스A_토큰으로_A의_run_조회시_200(self, client_factory, _db_session_factory):
+        app, session_factory = client_factory
+
+        ws_a_id, key_a, _ = await _create_workspace_with_key(session_factory, "A")
+        run_a_id = await _create_run(session_factory, ws_a_id)
+
+        with TestClient(app) as c:
+            resp = c.get(f"/api/v1/status/{run_a_id}", headers={"X-API-Key": key_a})
+
+        assert resp.status_code == 200
+        assert resp.json()["run_id"] == run_a_id
+
+
+class TestUsageEndpointIsolation:
+    """GET /usage/events 워크스페이스 격리 테스트."""
+
+    async def test_워크스페이스B_토큰으로_events_조회시_B_이벤트만_반환(self, client_factory, _db_session_factory):
+        app, session_factory = client_factory
+
+        ws_a_id, key_a, _ = await _create_workspace_with_key(session_factory, "A")
+        ws_b_id, key_b, _ = await _create_workspace_with_key(session_factory, "B")
+
+        run_a_id = await _create_run(session_factory, ws_a_id)
+        run_b_id = await _create_run(session_factory, ws_b_id)
+
+        event_a_id = await _create_usage_event(session_factory, run_a_id)
+        event_b_id = await _create_usage_event(session_factory, run_b_id)
+
+        with TestClient(app) as c:
+            resp = c.get("/api/v1/usage/events", headers={"X-API-Key": key_b})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        returned_ids = {e["id"] for e in data["events"]}
+        assert event_b_id in returned_ids
+        assert event_a_id not in returned_ids
+
+
+class TestAdminKeyWorkspaceIsolation:
+    """POST /admin/api-keys workspace_id 격리 테스트."""
+
+    async def test_api_키_생성시_workspace_id_일치(self, client_factory, _db_session_factory):
+        app, session_factory = client_factory
+
+        ws_a_id, key_a, _ = await _create_workspace_with_key(session_factory, "A")
+
+        with TestClient(app) as c:
+            resp = c.post(
+                "/api/v1/admin/api-keys",
+                json={"name": "새 키", "scopes": ["read", "write"]},
+                headers={"X-API-Key": key_a},
+            )
+
+        assert resp.status_code == 201
+        created_key_id = resp.json()["key_id"]
+
+        # DB에서 생성된 키의 workspace_id 확인
+        async with session_factory() as session:
+            repo = ApiKeyRepository(session)
+            created = await repo.get_by_id(created_key_id)
+        assert created is not None
+        assert created.workspace_id == ws_a_id

--- a/packages/api/yaa_app/api/main.py
+++ b/packages/api/yaa_app/api/main.py
@@ -18,6 +18,7 @@ from yaa_app.api.routes import (
     billing,
     channels,
     dashboard,
+    oauth,
     pipeline,
     plans,
     status,
@@ -94,6 +95,7 @@ def create_app() -> FastAPI:
     application.include_router(users.router, prefix="/api/v1/users", tags=["users"])
     application.include_router(plans.router, prefix="/api/v1/plans", tags=["plans"])
     application.include_router(billing.router, prefix="/api/v1/billing", tags=["billing"])
+    application.include_router(oauth.router, prefix="/api/v1/oauth", tags=["oauth"])
 
     return application
 

--- a/packages/api/yaa_app/api/routes/admin.py
+++ b/packages/api/yaa_app/api/routes/admin.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from yaa_core.database.engine import get_db_session
 from yaa_core.database.repositories import ApiKeyRepository, AuditLogRepository
 
-from yaa_app.api.auth import create_api_key, require_admin_scope
+from yaa_app.api.auth import AuthContext, create_api_key, get_auth_context, require_admin_scope
 from yaa_app.api.schemas import (
     ApiKeyInfo,
     ApiKeyListResponse,
@@ -34,6 +34,7 @@ async def create_key(
     request_body: CreateApiKeyRequest,
     session: AsyncSession = Depends(get_db_session),
     _admin_key_id: str | None = Depends(require_admin_scope),
+    auth: AuthContext = Depends(get_auth_context),
 ) -> CreateApiKeyResponse:
     """새 API 키를 생성합니다.
 
@@ -43,6 +44,7 @@ async def create_key(
         session=session,
         name=request_body.name,
         scopes=request_body.scopes,
+        workspace_id=auth.workspace_id,
     )
 
     repo = ApiKeyRepository(session)
@@ -75,10 +77,11 @@ async def list_keys(
     include_inactive: bool = Query(False, description="비활성 키 포함 여부"),
     session: AsyncSession = Depends(get_db_session),
     _admin_key_id: str | None = Depends(require_admin_scope),
+    auth: AuthContext = Depends(get_auth_context),
 ) -> ApiKeyListResponse:
     """등록된 API 키 목록을 조회합니다."""
     repo = ApiKeyRepository(session)
-    keys = await repo.get_all(include_inactive=include_inactive)
+    keys = await repo.get_all(include_inactive=include_inactive, workspace_id=auth.workspace_id)
 
     return ApiKeyListResponse(
         keys=[

--- a/packages/api/yaa_app/api/routes/oauth.py
+++ b/packages/api/yaa_app/api/routes/oauth.py
@@ -1,0 +1,46 @@
+"""OAuth 토큰 관리 API 엔드포인트."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from yaa_core.database.engine import get_db_session
+from yaa_core.database.repositories import OAuthTokenRepository
+
+from yaa_app.api.auth import AuthContext, get_auth_context
+
+router = APIRouter()
+
+
+@router.get("/youtube")
+async def get_youtube_token_status(
+    session: AsyncSession = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    """YouTube OAuth 연결 상태를 조회합니다."""
+    if not auth.workspace_id:
+        return {"connected": False, "updated_at": None}
+
+    repo = OAuthTokenRepository(session)
+    token = await repo.get_by_workspace(auth.workspace_id, provider="youtube")
+
+    if token is None:
+        return {"connected": False, "updated_at": None}
+
+    return {
+        "connected": True,
+        "updated_at": token.updated_at.isoformat() if token.updated_at else None,
+    }
+
+
+@router.delete("/youtube", status_code=204)
+async def delete_youtube_token(
+    session: AsyncSession = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
+) -> None:
+    """YouTube OAuth 토큰을 삭제합니다."""
+    if not auth.workspace_id:
+        return
+
+    repo = OAuthTokenRepository(session)
+    await repo.delete_by_workspace(auth.workspace_id, provider="youtube")

--- a/packages/api/yaa_app/api/routes/pipeline.py
+++ b/packages/api/yaa_app/api/routes/pipeline.py
@@ -374,6 +374,17 @@ async def retry_pipeline_run(
             status_code=400, detail=f"재실행할 수 없는 상태입니다: {original_run.status}"
         )
 
+    # 요금제 파이프라인 한도 검사 (재실행도 새 실행으로 카운트)
+    if auth.workspace_id:
+        ws_repo = WorkspaceRepository(session)
+        workspace = await ws_repo.get(auth.workspace_id)
+        if workspace:
+            await check_pipeline_quota(workspace, session)
+    elif auth.auth_method != "none":
+        raise HTTPException(
+            status_code=400, detail="파이프라인 실행에는 워크스페이스가 필요합니다."
+        )
+
     new_run_id = str(uuid.uuid4())
     await repo.create(
         run_id=new_run_id,

--- a/packages/api/yaa_app/api/routes/pipeline.py
+++ b/packages/api/yaa_app/api/routes/pipeline.py
@@ -348,3 +348,71 @@ async def stream_pipeline_run(
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
+
+
+@router.post("/runs/{run_id}/retry", response_model=PipelineRunResponse)
+async def retry_pipeline_run(
+    run_id: str,
+    background_tasks: BackgroundTasks,
+    settings: AppSettings = Depends(get_settings),
+    channel_registry: ChannelRegistry = Depends(get_channel_registry),
+    session: AsyncSession = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
+) -> PipelineRunResponse:
+    """실패하거나 취소된 파이프라인 실행을 동일한 파라미터로 재실행합니다."""
+    repo = RunRepository(session)
+    original_run = await repo.get(run_id)
+
+    if original_run is None:
+        raise HTTPException(status_code=404, detail="파이프라인 실행을 찾을 수 없습니다")
+
+    if original_run.workspace_id and original_run.workspace_id != auth.workspace_id:
+        raise HTTPException(status_code=404, detail="파이프라인 실행을 찾을 수 없습니다")
+
+    if original_run.status not in {"failed", "cancelled"}:
+        raise HTTPException(
+            status_code=400, detail=f"재실행할 수 없는 상태입니다: {original_run.status}"
+        )
+
+    new_run_id = str(uuid.uuid4())
+    await repo.create(
+        run_id=new_run_id,
+        channel_id=original_run.channel_id,
+        topic=original_run.topic,
+        brand_name=original_run.brand_name,
+        dry_run=original_run.dry_run,
+        workspace_id=original_run.workspace_id,
+    )
+
+    enqueued = False
+    try:
+        from yaa_app.worker.enqueue import enqueue_pipeline
+
+        enqueued = await enqueue_pipeline(
+            run_id=new_run_id,
+            channel_id=original_run.channel_id,
+            topic=original_run.topic,
+            brand_name=original_run.brand_name,
+            dry_run=original_run.dry_run,
+        )
+    except ImportError:
+        logger.debug("arq 패키지 미설치 — BackgroundTasks 폴백")
+
+    if not enqueued:
+        background_tasks.add_task(
+            _execute_pipeline,
+            run_id=new_run_id,
+            channel_id=original_run.channel_id,
+            topic=original_run.topic,
+            brand_name=original_run.brand_name,
+            dry_run=original_run.dry_run,
+            settings=settings,
+            channel_registry=channel_registry,
+        )
+
+    return PipelineRunResponse(
+        run_id=new_run_id,
+        status="pending",
+        channel_id=original_run.channel_id,
+        topic=original_run.topic,
+    )

--- a/packages/api/yaa_app/api/routes/pipeline.py
+++ b/packages/api/yaa_app/api/routes/pipeline.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import uuid
+from collections.abc import AsyncGenerator
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from yaa_core.database.engine import get_db_session, get_session_factory
 from yaa_core.database.repositories import RunRepository, UsageRepository, WorkspaceRepository
@@ -248,6 +252,9 @@ async def get_pipeline_run(
     if run.workspace_id and run.workspace_id != auth.workspace_id:
         raise HTTPException(status_code=404, detail="파이프라인 실행을 찾을 수 없습니다")
 
+    usage_repo = UsageRepository(session)
+    cost_usd = await usage_repo.get_run_cost(run_id)
+
     return PipelineRunDetail(
         run_id=run.id,
         channel_id=run.channel_id,
@@ -261,4 +268,83 @@ async def get_pipeline_run(
         completed_at=run.completed_at.isoformat() if run.completed_at else None,
         result=run.result,
         errors=run.errors or [],
+        cost_usd=cost_usd if cost_usd > 0 else None,
+    )
+
+
+@router.post("/runs/{run_id}/cancel")
+async def cancel_pipeline_run(
+    run_id: str,
+    session: AsyncSession = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict[str, str]:
+    """파이프라인 실행을 취소합니다."""
+    repo = RunRepository(session)
+    run = await repo.get(run_id)
+
+    if run is None:
+        raise HTTPException(status_code=404, detail="파이프라인 실행을 찾을 수 없습니다")
+
+    if run.workspace_id and run.workspace_id != auth.workspace_id:
+        raise HTTPException(status_code=404, detail="파이프라인 실행을 찾을 수 없습니다")
+
+    if run.status not in {"pending", "running"}:
+        raise HTTPException(status_code=400, detail=f"취소할 수 없는 상태입니다: {run.status}")
+
+    await repo.update_status(run_id, status="cancelled")
+
+    return {"run_id": run_id, "status": "cancelled"}
+
+
+@router.get("/runs/{run_id}/stream")
+async def stream_pipeline_run(
+    run_id: str,
+    session: AsyncSession = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
+) -> StreamingResponse:
+    """파이프라인 실행 상태를 SSE로 스트리밍합니다."""
+    repo = RunRepository(session)
+    run = await repo.get(run_id)
+
+    if run is None:
+        raise HTTPException(status_code=404, detail="파이프라인 실행을 찾을 수 없습니다")
+
+    if run.workspace_id and run.workspace_id != auth.workspace_id:
+        raise HTTPException(status_code=404, detail="파이프라인 실행을 찾을 수 없습니다")
+
+    async def event_generator() -> AsyncGenerator[str, None]:
+        session_factory = get_session_factory()
+        if session_factory is None:
+            return
+
+        terminal_statuses = {"completed", "failed", "cancelled"}
+        max_duration_seconds = 35 * 60  # 35분
+        elapsed = 0
+
+        while elapsed < max_duration_seconds:
+            async with session_factory() as poll_session:
+                poll_repo = RunRepository(poll_session)
+                current_run = await poll_repo.get(run_id)
+
+            if current_run is None:
+                break
+
+            data = {
+                "run_id": current_run.id,
+                "status": current_run.status,
+                "current_agent": current_run.current_agent,
+                "errors": current_run.errors,
+            }
+            yield f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+            if current_run.status in terminal_statuses:
+                break
+
+            await asyncio.sleep(2)
+            elapsed += 2
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/packages/api/yaa_app/api/routes/status.py
+++ b/packages/api/yaa_app/api/routes/status.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from yaa_core.database.engine import get_db_session
 from yaa_core.database.repositories import RunRepository
 
-from yaa_app.api.auth import require_api_key
+from yaa_app.api.auth import AuthContext, get_auth_context
 from yaa_app.api.schemas import PipelineStatusResponse
 
 router = APIRouter()
@@ -23,13 +23,16 @@ async def health_check() -> dict[str, str]:
 async def get_pipeline_status(
     run_id: str,
     session: AsyncSession = Depends(get_db_session),
-    _api_key_id: str | None = Depends(require_api_key),
+    auth: AuthContext = Depends(get_auth_context),
 ) -> PipelineStatusResponse:
     """파이프라인 실행 상태를 조회합니다."""
     repo = RunRepository(session)
     run = await repo.get(run_id)
 
     if run is None:
+        raise HTTPException(status_code=404, detail=f"실행을 찾을 수 없습니다: {run_id}")
+
+    if run.workspace_id and run.workspace_id != auth.workspace_id:
         raise HTTPException(status_code=404, detail=f"실행을 찾을 수 없습니다: {run_id}")
 
     return PipelineStatusResponse(

--- a/packages/api/yaa_app/api/routes/usage.py
+++ b/packages/api/yaa_app/api/routes/usage.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from yaa_core.database.engine import get_db_session
 from yaa_core.database.repositories import UsageRepository
 
-from yaa_app.api.auth import require_api_key
+from yaa_app.api.auth import AuthContext, get_auth_context
 from yaa_app.api.schemas import UsageEventResponse, UsageListResponse, UsageSummaryResponse
 
 router = APIRouter()
@@ -25,7 +25,7 @@ async def list_usage_events(
     limit: int = Query(20, ge=1, le=100, description="페이지 크기"),
     offset: int = Query(0, ge=0, description="오프셋"),
     session: AsyncSession = Depends(get_db_session),
-    _api_key_id: str | None = Depends(require_api_key),
+    auth: AuthContext = Depends(get_auth_context),
 ) -> UsageListResponse:
     """사용량 이벤트 목록을 조회합니다."""
     repo = UsageRepository(session)
@@ -38,6 +38,7 @@ async def list_usage_events(
         date_to=date_to,
         limit=limit,
         offset=offset,
+        workspace_id=auth.workspace_id,
     )
     total = await repo.count_with_filters(
         run_id=run_id,
@@ -45,6 +46,7 @@ async def list_usage_events(
         provider=provider,
         date_from=date_from,
         date_to=date_to,
+        workspace_id=auth.workspace_id,
     )
 
     return UsageListResponse(
@@ -75,7 +77,7 @@ async def get_usage_summary(
     date_from: datetime | None = Query(None, description="시작 일시 (ISO 8601)"),
     date_to: datetime | None = Query(None, description="종료 일시 (ISO 8601)"),
     session: AsyncSession = Depends(get_db_session),
-    _api_key_id: str | None = Depends(require_api_key),
+    auth: AuthContext = Depends(get_auth_context),
 ) -> UsageSummaryResponse:
     """사용량 집계 통계를 반환합니다."""
     repo = UsageRepository(session)
@@ -83,6 +85,7 @@ async def get_usage_summary(
         run_id=run_id,
         date_from=date_from,
         date_to=date_to,
+        workspace_id=auth.workspace_id,
     )
 
     return UsageSummaryResponse(

--- a/packages/api/yaa_app/api/schemas.py
+++ b/packages/api/yaa_app/api/schemas.py
@@ -75,6 +75,7 @@ class PipelineRunDetail(BaseModel):
     completed_at: str | None = None
     result: dict[str, Any] | None = None
     errors: list[str] = Field(default_factory=list)
+    cost_usd: float | None = None
 
 
 # ============================================

--- a/packages/api/yaa_app/worker/tasks.py
+++ b/packages/api/yaa_app/worker/tasks.py
@@ -79,6 +79,14 @@ async def execute_pipeline_task(
         await repo.update_status(run_id, status="running")
         await session.commit()
 
+    # 취소 레이스컨디션 가드: running 전환 직후 취소 여부 재확인
+    async with session_factory() as session:
+        repo = RunRepository(session)
+        current_run = await repo.get(run_id)
+        if current_run and current_run.status == "cancelled":
+            logger.info("파이프라인 취소됨 (워커 시작 전): run_id=%s", run_id)
+            return {"status": "cancelled", "run_id": run_id}
+
     collector = UsageCollector()
 
     try:

--- a/packages/api/yaa_app/worker/tasks.py
+++ b/packages/api/yaa_app/worker/tasks.py
@@ -167,3 +167,5 @@ class WorkerConfig:
     max_jobs = _settings.worker_max_jobs
     job_timeout = _settings.worker_job_timeout
     queue_name = _settings.worker_queue_name
+    retry_failed_jobs = True
+    max_tries = 3

--- a/packages/core/yaa_core/database/models.py
+++ b/packages/core/yaa_core/database/models.py
@@ -253,6 +253,27 @@ class AuditLogModel(Base):
     duration_ms: Mapped[float | None] = mapped_column(Float, nullable=True)
 
 
+class OAuthTokenModel(Base):
+    """OAuth 토큰 (YouTube 등) DB 저장."""
+
+    __tablename__ = "oauth_tokens"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    workspace_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        unique=True,
+    )
+    provider: Mapped[str] = mapped_column(String(20), nullable=False, default="youtube")
+    token_json: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
+    )
+
+
 class UsageEventModel(Base):
     """LLM 사용량 이벤트."""
 

--- a/packages/core/yaa_core/database/repositories.py
+++ b/packages/core/yaa_core/database/repositories.py
@@ -209,7 +209,7 @@ class RunRepository:
             values["result_json"] = json.dumps(result, ensure_ascii=False)
         if errors is not None:
             values["errors_json"] = json.dumps(errors, ensure_ascii=False)
-        if status in ("completed", "failed"):
+        if status in ("completed", "failed", "cancelled"):
             values["completed_at"] = datetime.now(UTC)
 
         await self._session.execute(

--- a/packages/core/yaa_core/database/repositories.py
+++ b/packages/core/yaa_core/database/repositories.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from yaa_core.database.models import (
     ApiKeyModel,
     AuditLogModel,
+    OAuthTokenModel,
     PipelineRunModel,
     SubscriptionModel,
     UsageEventModel,
@@ -776,4 +777,60 @@ class SubscriptionRepository:
             update(SubscriptionModel)
             .where(SubscriptionModel.id == subscription_id)
             .values(**kwargs)
+        )
+
+
+class OAuthTokenRepository:
+    """OAuth 토큰 저장소."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_workspace(
+        self, workspace_id: str, provider: str = "youtube"
+    ) -> OAuthTokenModel | None:
+        """워크스페이스 ID와 프로바이더로 토큰을 조회합니다."""
+        result = await self._session.execute(
+            select(OAuthTokenModel).where(
+                OAuthTokenModel.workspace_id == workspace_id,
+                OAuthTokenModel.provider == provider,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def upsert(
+        self, workspace_id: str, token_json: str, provider: str = "youtube"
+    ) -> OAuthTokenModel:
+        """토큰을 생성하거나 업데이트합니다."""
+        import uuid
+
+        existing = await self.get_by_workspace(workspace_id, provider)
+        if existing:
+            await self._session.execute(
+                update(OAuthTokenModel)
+                .where(OAuthTokenModel.id == existing.id)
+                .values(token_json=token_json, updated_at=datetime.now(UTC))
+            )
+            await self._session.flush()
+            return existing
+
+        token = OAuthTokenModel(
+            id=str(uuid.uuid4()),
+            workspace_id=workspace_id,
+            provider=provider,
+            token_json=token_json,
+        )
+        self._session.add(token)
+        await self._session.flush()
+        return token
+
+    async def delete_by_workspace(self, workspace_id: str, provider: str = "youtube") -> None:
+        """워크스페이스의 토큰을 삭제합니다."""
+        from sqlalchemy import delete as sa_delete
+
+        await self._session.execute(
+            sa_delete(OAuthTokenModel).where(
+                OAuthTokenModel.workspace_id == workspace_id,
+                OAuthTokenModel.provider == provider,
+            )
         )

--- a/packages/core/yaa_core/database/repositories.py
+++ b/packages/core/yaa_core/database/repositories.py
@@ -565,6 +565,7 @@ class UsageRepository:
         provider: str | None = None,
         date_from: datetime | None = None,
         date_to: datetime | None = None,
+        workspace_id: str | None = None,
     ) -> list:
         """필터 조건을 생성합니다."""
         conditions = []
@@ -578,6 +579,14 @@ class UsageRepository:
             conditions.append(UsageEventModel.created_at >= date_from)
         if date_to is not None:
             conditions.append(UsageEventModel.created_at <= date_to)
+        if workspace_id is not None:
+            conditions.append(
+                UsageEventModel.run_id.in_(
+                    select(PipelineRunModel.id).where(
+                        PipelineRunModel.workspace_id == workspace_id
+                    )
+                )
+            )
         return conditions
 
     async def list_with_filters(
@@ -589,9 +598,10 @@ class UsageRepository:
         date_to: datetime | None = None,
         limit: int = 20,
         offset: int = 0,
+        workspace_id: str | None = None,
     ) -> list[UsageEventModel]:
         """필터링과 페이지네이션을 지원하는 목록 조회."""
-        conditions = self._build_filter_query(run_id, agent, provider, date_from, date_to)
+        conditions = self._build_filter_query(run_id, agent, provider, date_from, date_to, workspace_id)
         query = (
             select(UsageEventModel)
             .where(*conditions)
@@ -609,9 +619,10 @@ class UsageRepository:
         provider: str | None = None,
         date_from: datetime | None = None,
         date_to: datetime | None = None,
+        workspace_id: str | None = None,
     ) -> int:
         """필터링된 결과의 총 개수를 반환합니다."""
-        conditions = self._build_filter_query(run_id, agent, provider, date_from, date_to)
+        conditions = self._build_filter_query(run_id, agent, provider, date_from, date_to, workspace_id)
         query = select(func.count(UsageEventModel.id)).where(*conditions)
         result = await self._session.execute(query)
         return result.scalar_one()
@@ -684,6 +695,14 @@ class UsageRepository:
             )
         else:
             query = select(func.coalesce(func.sum(UsageEventModel.cost_usd), 0.0))
+        result = await self._session.execute(query)
+        return float(result.scalar_one())
+
+    async def get_run_cost(self, run_id: str) -> float:
+        """특정 파이프라인 실행의 총 LLM 비용을 조회합니다."""
+        query = select(func.coalesce(func.sum(UsageEventModel.cost_usd), 0.0)).where(
+            UsageEventModel.run_id == run_id
+        )
         result = await self._session.execute(query)
         return float(result.scalar_one())
 

--- a/packages/frontend/e2e/pipeline-cancel.spec.ts
+++ b/packages/frontend/e2e/pipeline-cancel.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+const RUN_ID = 'run-active-001';
+
+test.describe('Pipeline Cancel', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route(`**/api/v1/pipeline/runs/${RUN_ID}`, (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    run_id: RUN_ID,
+                    channel_id: 'test-channel',
+                    topic: 'Active Topic',
+                    status: 'running',
+                    current_agent: 'script_writer',
+                    dry_run: false,
+                    created_at: new Date().toISOString(),
+                    updated_at: new Date().toISOString(),
+                    completed_at: null,
+                    errors: [],
+                }),
+            })
+        );
+
+        await page.route(`**/api/v1/pipeline/runs/${RUN_ID}/cancel`, (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ run_id: RUN_ID, status: 'cancelled' }),
+            })
+        );
+
+        // SSE stream mock (returns immediately)
+        await page.route(`**/api/v1/pipeline/runs/${RUN_ID}/stream`, (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'text/event-stream',
+                body: `data: {"run_id":"${RUN_ID}","status":"running","current_agent":"script_writer","errors":[]}\n\n`,
+            })
+        );
+    });
+
+    test('활성 파이프라인에 Cancel 버튼이 표시된다', async ({ page }) => {
+        await page.goto(`/pipelines/${RUN_ID}`);
+        await expect(page.getByRole('button', { name: /cancel/i })).toBeVisible();
+    });
+
+    test('Cancel 버튼 클릭 시 취소 API가 호출된다', async ({ page }) => {
+        let cancelCalled = false;
+        await page.route(`**/api/v1/pipeline/runs/${RUN_ID}/cancel`, (route) => {
+            cancelCalled = true;
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ run_id: RUN_ID, status: 'cancelled' }),
+            });
+        });
+
+        await page.goto(`/pipelines/${RUN_ID}`);
+        await page.getByRole('button', { name: /cancel/i }).click();
+
+        await expect(async () => {
+            expect(cancelCalled).toBe(true);
+        }).toPass({ timeout: 3000 });
+    });
+});

--- a/packages/frontend/e2e/pipeline-create.spec.ts
+++ b/packages/frontend/e2e/pipeline-create.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_RUN_ID = 'test-run-id-create-001';
+
+test.describe('Pipeline Create', () => {
+    test.beforeEach(async ({ page }) => {
+        // Mock channels API
+        await page.route('**/api/v1/channels', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    channels: [
+                        { channel_id: 'test-channel', name: 'Test Channel', category: 'general', has_brand_guide: false },
+                    ],
+                    total: 1,
+                }),
+            })
+        );
+
+        // Mock pipeline run creation
+        await page.route('**/api/v1/pipeline/run', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    run_id: MOCK_RUN_ID,
+                    status: 'pending',
+                    channel_id: 'test-channel',
+                    topic: 'Test Topic',
+                }),
+            })
+        );
+
+        // Mock pipeline detail
+        await page.route(`**/api/v1/pipeline/runs/${MOCK_RUN_ID}`, (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    run_id: MOCK_RUN_ID,
+                    channel_id: 'test-channel',
+                    topic: 'Test Topic',
+                    status: 'pending',
+                    current_agent: null,
+                    dry_run: false,
+                    created_at: new Date().toISOString(),
+                    updated_at: new Date().toISOString(),
+                    completed_at: null,
+                    errors: [],
+                }),
+            })
+        );
+    });
+
+    test('폼 제출 후 상세 페이지로 이동하고 Pending 배지가 표시된다', async ({ page }) => {
+        await page.goto('/pipelines/new');
+
+        // Fill in the form
+        await page.selectOption('select[name="channel_id"]', 'test-channel');
+        await page.fill('input[name="topic"]', 'Test Topic');
+
+        // Submit
+        await page.click('button[type="submit"]');
+
+        // Should redirect to detail page
+        await page.waitForURL(`**/pipelines/${MOCK_RUN_ID}`);
+
+        // Pending badge should be visible
+        await expect(page.getByText('Pending')).toBeVisible();
+    });
+});

--- a/packages/frontend/e2e/pipeline-list.spec.ts
+++ b/packages/frontend/e2e/pipeline-list.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_RUNS = [
+    {
+        run_id: 'run-001',
+        channel_id: 'channel-a',
+        topic: 'Topic A',
+        status: 'completed',
+        dry_run: false,
+        created_at: new Date(Date.now() - 3600000).toISOString(),
+        completed_at: new Date().toISOString(),
+    },
+    {
+        run_id: 'run-002',
+        channel_id: 'channel-b',
+        topic: 'Topic B',
+        status: 'failed',
+        dry_run: false,
+        created_at: new Date(Date.now() - 7200000).toISOString(),
+        completed_at: null,
+    },
+    {
+        run_id: 'run-003',
+        channel_id: 'channel-a',
+        topic: 'Topic C',
+        status: 'running',
+        dry_run: false,
+        created_at: new Date().toISOString(),
+        completed_at: null,
+    },
+];
+
+test.describe('Pipeline List', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v1/pipeline/runs**', (route) => {
+            const url = new URL(route.request().url());
+            const statusFilter = url.searchParams.get('status');
+            const runs = statusFilter
+                ? MOCK_RUNS.filter((r) => r.status === statusFilter)
+                : MOCK_RUNS;
+
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ runs, total: runs.length, limit: 20, offset: 0 }),
+            });
+        });
+    });
+
+    test('파이프라인 목록이 렌더링된다', async ({ page }) => {
+        await page.goto('/pipelines');
+
+        await expect(page.getByText('Topic A')).toBeVisible();
+        await expect(page.getByText('Topic B')).toBeVisible();
+        await expect(page.getByText('Topic C')).toBeVisible();
+    });
+
+    test('행 클릭 시 상세 페이지로 이동한다', async ({ page }) => {
+        // Mock detail page
+        await page.route('**/api/v1/pipeline/runs/run-001', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    ...MOCK_RUNS[0],
+                    brand_name: '',
+                    current_agent: null,
+                    result: null,
+                    errors: [],
+                    updated_at: MOCK_RUNS[0].created_at,
+                }),
+            })
+        );
+
+        await page.goto('/pipelines');
+        await page.getByText('Topic A').click();
+        await page.waitForURL('**/pipelines/run-001');
+    });
+});

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.20",
@@ -23,6 +24,7 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
     "@fontsource/inter": "^5.2.8",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/frontend/playwright.config.ts
+++ b/packages/frontend/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './e2e',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: 'html',
+    use: {
+        baseURL: 'http://localhost:3000',
+        trace: 'on-first-retry',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+    webServer: {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+    },
+});

--- a/packages/frontend/src/app/(app)/pipelines/[id]/page.tsx
+++ b/packages/frontend/src/app/(app)/pipelines/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { usePipeline, PIPELINE_STAGES } from '@/hooks/use-pipeline';
+import { usePipeline, useCancelPipeline, useRetryPipeline, usePipelineSSE, PIPELINE_STAGES } from '@/hooks/use-pipeline';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Plus, RotateCcw, ExternalLink, CheckCircle, Circle, Loader2, XCircle } from 'lucide-react';
@@ -15,6 +15,7 @@ function getStageStatus(currentAgent: string | null, stageKey: string, pipelineS
         if (stageIndex < currentIndex) return 'completed';
         return 'pending';
     }
+    if (pipelineStatus === 'cancelled') return 'pending';
     if (pipelineStatus === 'completed') return 'completed';
     if (!currentAgent) return 'pending';
 
@@ -49,6 +50,8 @@ function getStatusBadge(status: string) {
             return <Badge className="bg-red-500/20 text-red-400 border-red-500/30">Failed</Badge>;
         case 'pending':
             return <Badge className="bg-yellow-500/20 text-yellow-400 border-yellow-500/30">Pending</Badge>;
+        case 'cancelled':
+            return <Badge className="bg-gray-500/20 text-gray-400 border-gray-500/30">Cancelled</Badge>;
         default:
             return <Badge variant="secondary">{status}</Badge>;
     }
@@ -59,6 +62,10 @@ export default function PipelineDetailPage() {
     const id = params?.id as string;
 
     const { data: pipeline, isLoading, error } = usePipeline(id);
+    const cancelMutation = useCancelPipeline();
+    const retryMutation = useRetryPipeline();
+    const isActive = pipeline?.status === 'pending' || pipeline?.status === 'running';
+    usePipelineSSE(isActive ? id : '');
 
     if (isLoading) {
         return (
@@ -108,6 +115,19 @@ export default function PipelineDetailPage() {
                 </div>
                 <div className="flex items-center gap-3">
                     {getStatusBadge(pipeline.status)}
+                    {(pipeline.status === 'pending' || pipeline.status === 'running') && (
+                        <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => cancelMutation.mutate(id)}
+                            disabled={cancelMutation.isPending}
+                        >
+                            {cancelMutation.isPending
+                                ? <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                : <XCircle className="mr-2 h-4 w-4" />}
+                            Cancel
+                        </Button>
+                    )}
                     {(pipeline.status === 'completed' || pipeline.status === 'failed') && (
                         <Button variant="outline" size="sm" asChild>
                             <Link href="/pipelines/new">
@@ -197,6 +217,12 @@ export default function PipelineDetailPage() {
                                     <dd>{new Date(pipeline.completed_at).toLocaleString()}</dd>
                                 </div>
                             )}
+                            {pipeline.cost_usd != null && (
+                                <div>
+                                    <dt className="text-muted-foreground">LLM Cost</dt>
+                                    <dd className="font-mono">${pipeline.cost_usd.toFixed(4)}</dd>
+                                </div>
+                            )}
                         </dl>
                     </div>
 
@@ -242,11 +268,17 @@ export default function PipelineDetailPage() {
                         )}
                     </div>
 
-                    {pipeline.status === 'failed' && (
-                        <Button variant="outline" className="w-full" asChild>
-                            <Link href="/pipelines/new">
-                                <RotateCcw className="mr-2 h-4 w-4" /> Retry with Same Topic
-                            </Link>
+                    {(pipeline.status === 'failed' || pipeline.status === 'cancelled') && (
+                        <Button
+                            variant="outline"
+                            className="w-full"
+                            onClick={() => retryMutation.mutate(id)}
+                            disabled={retryMutation.isPending}
+                        >
+                            {retryMutation.isPending
+                                ? <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                : <RotateCcw className="mr-2 h-4 w-4" />}
+                            Retry with Same Topic
                         </Button>
                     )}
                 </div>

--- a/packages/frontend/src/hooks/use-pipeline.ts
+++ b/packages/frontend/src/hooks/use-pipeline.ts
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 
@@ -6,7 +8,7 @@ export interface PipelineRunDetail {
     channel_id: string;
     topic: string;
     brand_name?: string;
-    status: 'pending' | 'running' | 'completed' | 'failed';
+    status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
     current_agent: string | null;
     dry_run: boolean;
     created_at: string;
@@ -18,6 +20,7 @@ export interface PipelineRunDetail {
         images?: string[];
     } | null;
     errors: string[];
+    cost_usd?: number | null;
 }
 
 export interface PipelineRunsResponse {
@@ -44,7 +47,7 @@ export function usePipeline(runId: string) {
         refetchInterval: (query) => {
             const data = query.state.data;
             if (!data) return 1000;
-            return ['completed', 'failed'].includes(data.status) ? false : 5000;
+            return ['completed', 'failed', 'cancelled'].includes(data.status) ? false : 5000;
         },
     });
 }
@@ -81,4 +84,70 @@ export function useCreatePipeline() {
             queryClient.invalidateQueries({ queryKey: ['pipeline', 'runs'] });
         },
     });
+}
+
+export function useCancelPipeline() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (runId: string) =>
+            api.post<{ run_id: string; status: string }>(`/pipeline/runs/${runId}/cancel`, {}),
+        onSuccess: (_data, runId) => {
+            queryClient.invalidateQueries({ queryKey: ['pipeline', runId] });
+            queryClient.invalidateQueries({ queryKey: ['pipeline', 'runs'] });
+        },
+    });
+}
+
+export function useRetryPipeline() {
+    const queryClient = useQueryClient();
+    const router = useRouter();
+
+    return useMutation({
+        mutationFn: (runId: string) =>
+            api.post<{ run_id: string; status: string; channel_id: string; topic: string }>(
+                `/pipeline/runs/${runId}/retry`,
+                {}
+            ),
+        onSuccess: (data) => {
+            queryClient.invalidateQueries({ queryKey: ['pipeline', 'runs'] });
+            router.push(`/pipelines/${data.run_id}`);
+        },
+    });
+}
+
+export function usePipelineSSE(runId: string) {
+    const queryClient = useQueryClient();
+    const esRef = useRef<EventSource | null>(null);
+
+    useEffect(() => {
+        if (!runId) return;
+
+        const es = new EventSource(`/api/v1/pipeline/runs/${runId}/stream`);
+        esRef.current = es;
+
+        es.onmessage = (event) => {
+            try {
+                const data: Partial<PipelineRunDetail> = JSON.parse(event.data);
+                queryClient.setQueryData(['pipeline', runId], (old: PipelineRunDetail | undefined) =>
+                    old ? { ...old, ...data } : data
+                );
+                if (data.status && ['completed', 'failed', 'cancelled'].includes(data.status)) {
+                    es.close();
+                }
+            } catch {
+                // ignore parse errors
+            }
+        };
+
+        es.onerror = () => {
+            es.close();
+        };
+
+        return () => {
+            es.close();
+        };
+    }, [runId, queryClient]);
+
+    return { isStreaming: esRef.current?.readyState === EventSource.OPEN };
 }


### PR DESCRIPTION
## Summary

- **9-1 Security**: `GET /status/{id}`, `GET /usage/events`, `GET /usage/summary`, `POST/GET /admin/api-keys` 모두 workspace_id 격리 적용. `UsageRepository` workspace 서브쿼리 필터 추가.
- **9-2 UX**: `POST /runs/{id}/cancel`, `GET /runs/{id}/stream` (SSE), `PipelineRunDetail.cost_usd` 필드, 취소 레이스컨디션 가드. 프론트엔드 Cancel 버튼, 비용 표시, Cancelled 배지, SSE 훅.
- **9-3 E2E**: `POST /runs/{id}/retry` 재실행 엔드포인트, `WorkerConfig.max_tries=3`, Playwright 설정 + 3개 E2E 스펙 (create/list/cancel).
- **9-4 YouTube**: `OAuthTokenModel` + Alembic 마이그레이션 (`e5f6a7b8c9d0`), `OAuthTokenRepository`, `YouTubeUploader` DB 토큰 우선 + `_execute_upload_with_retry` (지수 백오프), `GET/DELETE /oauth/youtube`.

## Changed Files

| Phase | 파일 |
|-------|------|
| 9-1 | `routes/status.py`, `routes/usage.py`, `routes/admin.py`, `repositories.py`, `tests/test_auth_isolation.py` (신규) |
| 9-2 | `routes/pipeline.py`, `schemas.py`, `repositories.py`, `worker/tasks.py`, `use-pipeline.ts`, `pipelines/[id]/page.tsx` |
| 9-3 | `routes/pipeline.py`, `worker/tasks.py`, `use-pipeline.ts`, `pipelines/[id]/page.tsx`, `playwright.config.ts` (신규), `e2e/*.spec.ts` 3개 (신규) |
| 9-4 | `models.py`, `repositories.py`, `alembic/versions/e5f6a7b8c9d0_*`, `publisher/youtube_api.py`, `routes/oauth.py` (신규), `main.py` |

## Test plan

- [ ] `make test` — 기존 테스트 통과 확인
- [ ] `pytest packages/api/tests/test_auth_isolation.py` — 격리 테스트 3개 통과
- [ ] `make db-upgrade` — `oauth_tokens` 테이블 생성 확인
- [ ] `GET /status/{타_workspace_run_id}` → 404 확인
- [ ] `POST /runs/{id}/cancel` → status=cancelled 반환
- [ ] `GET /runs/{id}/stream` → SSE 이벤트 스트림 확인 (`curl -N`)
- [ ] `POST /runs/{failed_id}/retry` → 새 run_id 반환
- [ ] `GET /oauth/youtube` → `{"connected": false}` 반환
- [ ] `pnpm test:e2e` — 3개 Playwright 시나리오 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)